### PR TITLE
Only check max_quantity on creation of new transfer; fixes #202

### DIFF
--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -35,7 +35,7 @@ class Transfer < ActiveRecord::Base
   validates :quantity, presence: true
   validates_exclusion_of :quantity, in: 0..0, message: 'Positive or negative quantities'
   validates_associated :comments
-  validate :check_max_quantities
+  validate :check_max_quantities, on: :create
 
   def check_max_quantities
     shelf = organization.shelves.where('warehouse_id = ? and batch_id = ?', from_warehouse_id,  batch_id).first


### PR DESCRIPTION
I believe I found the culprit for issue #202 "Unable to receive transfers"

There was a validation added back in october: #98 that ensures there is enough packages on the "FROM_WAREHOUSE" for the transfer to be valid.

However, this validation is also done on all "updates".
A state change, such as `#receive_package` does the normal `#save` which runs the validations.

This has worked before because the transfers have been small, and the sending warehouse has always had more in stock than the transfer was.

ping @maxhansson 