### PR TITLE
use of ActiveRecord#includes cuts number of n+1 queries

### DIFF
--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -10,6 +10,7 @@ class TransfersController < ApplicationController
   # GET /transfers.json
   def index
     @breadcrumbs = [['Transfers']]
+    @transfers = @transfers.includes(:from_warehouse, :to_warehouse, :batch)
     transfers = TransferDecorator.decorate_collection(@transfers.order('id DESC'))
     @transfers = Kaminari.paginate_array(transfers).page(params[:page])
   end


### PR DESCRIPTION
This is a trick to fix the "n+1 query"[0] problem in  rails `ActiveRecord`

This PullRequest fixes this issue in `TransferController#index`
[0] https://secure.phabricator.com/book/phabcontrib/article/n_plus_one/