### PR TITLE
Import_bank_file: use paperclip

### DIFF
--- a/app/controllers/import_bank_file_rows_controller.rb
+++ b/app/controllers/import_bank_file_rows_controller.rb
@@ -98,7 +98,9 @@ class ImportBankFileRowsController < ApplicationController
         @verificates.push(verificate)
       end
     end
-    @templates = current_organization.templates.where('template_type = ?', 'cost')
+    template_type = 'cost'
+    template_type = 'income' if @import_bank_file_row.amount > 0
+    @templates = current_organization.templates.where('template_type = ?', template_type)
   end
 
   def set_template_verificate

--- a/app/models/import_bank_file.rb
+++ b/app/models/import_bank_file.rb
@@ -5,20 +5,61 @@ class ImportBankFile < ActiveRecord::Base
   # t.datetime :to_date
   # t.string   :reference
   # t.integer  :organization_id
+  # t.integer  :user_id
+  # t.string   :state
   # t.timestamps
 
-  attr_accessible :import_date, :from_date, :to_date, :reference
+  VALID_EVENTS = %w(import_event)
+
+  attr_accessible :import_date, :from_date, :to_date, :reference, :upload
 
   has_attached_file :upload
   belongs_to :organization
-  has_many   :import_bank_file_rows, dependent: :destroy
-  # validates_attachment_content_type :upload, content_type: ['text/csv']
+  belongs_to :user
+  has_many :import_bank_file_rows, dependent: :destroy
+
+  validates_attachment_content_type :upload, content_type: ['text/csv']
+  validates_presence_of :organization_id
+  validates_presence_of :user_id
+
+  after_commit :enqueue_import_event, on: :create
 
   def name
     'Nordea'
   end
 
   def can_delete?
-    true
+    (!completed?)
+  end
+
+  def enqueue_import_event
+    if completed?
+      logger.info "** ImportBankFile #{id} already completed, will not enqueue_event"
+      return
+    end
+    logger.info '** ImportBankFile enqueue a job that will parse the imported file.'
+    Resque.enqueue(Job::ImportBankFileEvent, id, 'import_event')
+  end
+
+  # Run from the 'Job::ImportBankFile' model
+  def import_event
+    return nil if completed?
+    parse_and_import = Services::ImportBankFileCreator.new(self)
+    if parse_and_import.read_and_save_nordea
+      logger.info "** ImportBankFile #{id} parse/import returned ok, marking complete"
+      complete
+    else
+      logger.info "** ImportBankFile #{id} parse/import did NOT return ok, not marking complete"
+    end
+  end
+
+  state_machine :state, initial: :created do
+    event :complete do
+      transition created: :completed
+    end
+  end
+
+  def completed?
+    state.eql? 'completed'
   end
 end

--- a/app/models/job/import_bank_file_event.rb
+++ b/app/models/job/import_bank_file_event.rb
@@ -1,0 +1,17 @@
+module Job
+  class ImportBankFileEvent
+    @queue = :import_bank_file_events
+    def self.perform(import_bank_file_id, event_name)
+      import_bank_file = ImportBankFile.find(import_bank_file_id)
+      if ImportBankFile::VALID_EVENTS.include?(event_name)
+        Rails.logger.info "will execute #{event_name} on #{import_bank_file.id}"
+        import_bank_file.send(event_name)
+      else
+        Rails.logger.info "** Job::ImportBankFileEvent unknown event_name(#{event_name})"
+      end
+    rescue ActiveRecord::RecordNotFound
+      Rails.logger.info '** Job::ImportBankFileEvent could not find ' \
+        "object with id #{import_bank_file_id}"
+    end
+  end
+end

--- a/app/views/import_bank_file_rows/match_verificate.html.haml
+++ b/app/views/import_bank_file_rows/match_verificate.html.haml
@@ -2,7 +2,7 @@
   %table{:class => 'table table-striped'}
     %thead
       %tr
-        %th= t(:date)
+        %th= t(:posting_date)
         %th= t(:description)
         %th= t(:name)
         %th= t(:choose)

--- a/app/views/import_bank_files/_form.html.haml
+++ b/app/views/import_bank_files/_form.html.haml
@@ -1,10 +1,9 @@
-= simple_form_for(@template, wrapper: :horizontal_form, html: {class: 'form-horizontal'}) do |f|
+= simple_form_for(@import_bank_file,
+  wrapper: :horizontal_form,
+  html: {class: 'form-horizontal', multipart: true}) do |f|
   = f.error_notification
-  = f.association :accounting_plan, disabled: !@template.new_record?
-  = f.input :name, disabled: !@template.new_record?
-  = f.input :description, disabled: !@template.new_record?
-
-  - if @template.new_record?
+  = f.input :upload, wrapper: :horizontal_file_input, accept: 'text/csv'
+  - if @import_bank_file.new_record?
     .form-button-group
       .actions
         = f.submit class: 'btn btn-primary'

--- a/app/views/import_bank_files/index.html.haml
+++ b/app/views/import_bank_files/index.html.haml
@@ -1,4 +1,4 @@
-= link_to "#{t(:upload)} #{t(:bank_file)}", import_bank_file_upload_path(0), class: 'btn btn-success'
+= link_to "#{t(:upload)} #{t(:bank_file)}", new_import_bank_file_path, class: 'btn btn-success'
 
 .table-responsive{:ng_controller=>'ModalCtrl'}
   %table{:class => 'table table-striped'}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,8 +93,6 @@ Emmy::Application.routes.draw do
     get 'helps/show_chapter_help'
     get 'helps/show_message'
     resources :import_bank_files do
-      get  'upload', as: :upload
-      post 'create_from_upload', as: :create_from_upload
       resources :import_bank_file_rows do
         get 'match_verificate', as: :match_verificate
         get 'set_verificate', as: :set_verificate

--- a/db/migrate/20160328132321_add_state_to_import_bank_file.rb
+++ b/db/migrate/20160328132321_add_state_to_import_bank_file.rb
@@ -1,0 +1,6 @@
+class AddStateToImportBankFile < ActiveRecord::Migration
+  def change
+    add_column :import_bank_files, :state, :string
+    add_attachment :import_bank_files, :upload
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150801161447) do
+ActiveRecord::Schema.define(version: 20160328132321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -329,6 +329,12 @@ ActiveRecord::Schema.define(version: 20150801161447) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "completed_at"
+    t.string   "state"
+    t.string   "upload_file_name"
+    t.string   "upload_content_type"
+    t.integer  "upload_file_size"
+    t.datetime "upload_updated_at"
   end
 
   create_table "imports", force: true do |t|


### PR DESCRIPTION
This uses the `#path` method from paperclip to access the file.

I refactored the `Job` -part a bit.
The argument behind this refactorization is that the `Job` should only be responsible for calling the correct `method` on the model, and should not contain business logic in it self.

Business logic should either be in the `model` or a `service object`.
Never in a `Controller` or a `job`.

The same thing as the job does here (triggering a parse/import of a file into import_file_rows) should be possible even if there was no concept of "background jobs".