### PR TITLE
Adds a rake task to recalculate all shelves

### DIFF
--- a/lib/tasks/eko.rake
+++ b/lib/tasks/eko.rake
@@ -37,4 +37,13 @@ namespace :eko do
       verificate_creator.customer_payments
     end
   end
+
+  desc 'recalculate all shelves'
+  task :recalculate_all_shelves => :environment do |_,_|
+    Shelf.all.each do |shelf|
+      puts "recalculating shelf: #{shelf.id} #{shelf.warehouse.name} #{shelf.batch.item.name}"
+      shelf.recalculate
+      puts
+    end
+  end
 end


### PR DESCRIPTION
Makes it possible to manually trigger recalculation that is done by the resque/background-job to cache the shelf quantity.