### PR TITLE
fix db:seed by adding a org type

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,6 +19,8 @@ jtest = User.new({
 })
 jtest.default_organization_id = 3
 [o,o2,o3].each do |org|
+  org.organization_type = 'Aktiebolag'
+  org.save!
   r = jtest.organization_roles.build(name: OrganizationRole::ROLE_ADMIN)
   r.organization_id = org.id
 end


### PR DESCRIPTION
Since the introduction of the mandatory organization_type `rake db:seed` have been broken.

This PR sets the `organization_type` to 'Aktiebolag' for the seed organizations.

ping @maxhansson Please review.