### PR TITLE
change order of manuals#index

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -8,6 +8,7 @@ class ManualsController < ApplicationController
   def index
     @breadcrumbs = [['Manuals']]
     @manuals = current_organization.manuals.page(params[:page])
+                                           .order('created_at desc')
   end
 
   # GET /manuals/1


### PR DESCRIPTION
The order of manual transactions on the index page was oldest-first, this pr changes that.