### PR TITLE
on pdf invoice: make far-right total inc vat

### DIFF
--- a/app/views/sales/_invoice.pdf.haml
+++ b/app/views/sales/_invoice.pdf.haml
@@ -65,7 +65,7 @@
               %td.numeric
                 = "(#{item.vat}%) "
                 = as_sek(item.total_vat, '')
-              %td.numeric= as_sek(item.price_sum, '')
+              %td.numeric= as_sek((item.price_sum + item.total_vat), '')
           %tr.filler
             %td{colspan: '5'} &nbsp;
         %tfoot


### PR DESCRIPTION
On the PDF invoice, display the price inc vat instead of ex vat.


fixes #265