### PR TITLE
Add a basic sales report statistics

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -159,6 +159,18 @@ class ReportsController < ApplicationController
     end
   end
 
+  def sale_statistics
+    @breadcrumbs = [[t(:sale_statistics)]]
+    # Statistics::SaleStat.from_params will return early if params[..].blank?
+    @sale_stats = Statistics::SaleStat.list_from_params(current_organization,
+                                                   params[:newer_than],
+                                                   params[:older_than])
+    @sale_stat_sum = Statistics::SaleStat.as_sumarized(@sale_stats)
+    respond_to do |format|
+      format.html
+    end
+  end
+
   private
 
   def load_accounting_period

--- a/app/models/statistics/sale_stat.rb
+++ b/app/models/statistics/sale_stat.rb
@@ -1,0 +1,75 @@
+module Statistics
+  class SaleStat
+    attr_accessor :warehouse, :num_pkg, :sum_amount,
+                  :batch_names, :num_sales
+
+    def initialize(args = {})
+      @batch_names = []
+      @num_pkg = 0
+      @sum_amount = 0
+      @num_sales = 0
+      @warehouse = args[:warehouse]
+    end
+
+    def self.list_from_params(organization, newer_than, older_than)
+      return [] if newer_than.blank? || older_than.blank?
+      sale_stats = []
+      newer_than = "#{newer_than}-01"
+      older_than = "#{older_than}-01"
+      warehouses = organization.warehouses
+      warehouses.each do |w|
+        sale_stat = from_warehouse_between(w, newer_than, older_than)
+        sale_stats << sale_stat if sale_stat.num_sales > 0
+      end
+      sale_stats
+    end
+
+    def self.from_warehouse_between(warehouse, newer_than, older_than)
+      sales = sales_from_warehouse(warehouse, newer_than, older_than)
+      new_from_sales(warehouse, sales)
+    end
+
+    def self.new_from_sales(warehouse, sales)
+      sale_stat = new(warehouse: warehouse)
+      sales.map do |sale|
+        sale_stat.num_sales += 1
+        sale.sale_items.map do |item|
+          add_item_to(sale_stat, item)
+        end
+      end
+      sale_stat
+    end
+
+    def self.add_item_to(sale_stat, item)
+      sale_stat.num_pkg += item.quantity
+      sale_stat.sum_amount += item.price_sum
+      if item.batch && !sale_stat.batch_names.include?(item.batch.name)
+        sale_stat.batch_names << item.batch.name
+      end
+    end
+
+    def self.sales_from_warehouse(warehouse, newer_than, older_than)
+      warehouse.sales
+               .where('approved_at >= ?', newer_than)
+               .where('approved_at <= ?', older_than)
+               .includes(:sale_items)
+    end
+
+    def self.as_sumarized(sale_stats)
+      sale_stat_sum = new
+      sale_stat_sum.num_sales = sale_stats.map(&:num_sales).sum
+      sale_stat_sum.batch_names = sale_stats.map(&:batch_names)
+      sale_stat_sum.num_pkg = sale_stats.map(&:num_pkg).sum
+      sale_stat_sum.sum_amount = sale_stats.map(&:sum_amount).sum
+      sale_stat_sum
+    end
+
+    def self.logger
+      Rails.logger
+    end
+
+    def logger
+      self.class.logger
+    end
+  end
+end

--- a/app/models/warehouse.rb
+++ b/app/models/warehouse.rb
@@ -13,6 +13,7 @@ class Warehouse < ActiveRecord::Base
   has_many :comments, as: :parent
   has_many :batch_transactions
   has_many :manuals, through: :batch_transactions, source: :parent, source_type: 'Manual'
+  has_many :sales
 
   attr_accessible :name, :address, :zip, :city, :primary_contact_id
 

--- a/app/views/reports/sale_statistics.html.haml
+++ b/app/views/reports/sale_statistics.html.haml
@@ -1,0 +1,40 @@
+.row
+  .col-sm-40.col-md-40.pull-right.text-right
+    = form_tag reports_sale_statistics_path, class: 'form-inline submit-on-change', method: :get, enforce_utf8: false do
+      = text_field_tag('locale' , params[:locale], type:'hidden')
+
+      = select_tag(:newer_than,
+        options_for_select(months_list, params[:newer_than]),
+        class: 'btn btn-default',
+        prompt: "#{t(:filter)} #{t(:newer_than)}: #{t(:all)}")
+
+      = select_tag(:older_than,
+        options_for_select(months_list, params[:older_than]),
+        class: 'btn btn-default',
+        prompt: "#{t(:filter)} #{t(:older_than)}: #{t(:all)}")
+
+.table-responsive
+  %table{:class => 'table table-striped'}
+    %thead
+      %tr
+        %th= t(:warehouse)
+        %th= t(:num_sales)
+        %th= t(:batch)
+        %th= t(:num_pkg)
+        %th= t(:sum_amount)
+    %tbody
+      - @sale_stats.each do |sale_stat|
+        %tr
+          %td= link_to sale_stat.warehouse.name, warehouse_path(sale_stat.warehouse)
+          %td= sale_stat.num_sales
+          %td= sale_stat.batch_names
+          %td= sale_stat.num_pkg
+          %td= as_sek(sale_stat.sum_amount)
+
+    %tfoot
+      %tr
+        %th= t(:sum)
+        %th= @sale_stat_sum.num_sales
+        %th= @sale_stat_sum.batch_names
+        %th= @sale_stat_sum.num_pkg
+        %th= as_sek(@sale_stat_sum.sum_amount)

--- a/app/views/shared/_sidebar.html.haml
+++ b/app/views/shared/_sidebar.html.haml
@@ -106,4 +106,5 @@
             = nav_link t(:ledger), reports_order_ledger_report_path
             = nav_link t(:results), reports_order_result_report_path
             = nav_link t(:balances), reports_order_balance_report_path
+            = nav_link t(:sale_statistics), reports_sale_statistics_path
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,6 +137,7 @@ Emmy::Application.routes.draw do
     get 'reports/order_ledger_report'
     get 'reports/order_result_report'
     get 'reports/order_balance_report'
+    get 'reports/sale_statistics'
     post 'reports/verificates'
     post 'reports/ledger'
     post 'reports/result_report'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -278,9 +278,9 @@ ActiveRecord::Schema.define(version: 20170501155846) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "state",
-    t.string   "download_file_name",
-    t.string   "download_content_type",
+    t.string   "state"
+    t.string   "download_file_name"
+    t.string   "download_content_type"
     t.integer  "download_file_size"
     t.datetime "download_updated_at"
   end


### PR DESCRIPTION
At least one user needs a way to get the number of sold packages between two dates (calendar year)

This PR implements a basic list of sales, grouped by warehouse between two dates.