### PR TITLE
Fix issue with typeahead sales new

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -44,13 +44,15 @@ RUN gem update --system \
 WORKDIR /app
 
 RUN adduser --disabled-password --gecos=" " --uid 1000 user
+
+COPY Gemfile* /app/
+RUN chown user:user -R /app
+RUN apt update && apt install netcat-openbsd -y
 USER user
 ENV BUNDLE_PATH=/home/user/.gems \
     GEM_HOME=/home/user/.gems  \
     BUNDLE_APP_CONFIG=/home/user/.gems \
     PATH=/home/user/.gems/bin:$PATH
-
-COPY Gemfile* /app/
 RUN gem install bundler && gem install rake -v '12.3.1'
 
 RUN bundle install && gem install mailcatcher

--- a/app/views/sales/_select_customer.html.haml
+++ b/app/views/sales/_select_customer.html.haml
@@ -60,17 +60,34 @@
       }
     }
     function set_contact(customer) {
-      $('#sale_contact_name').val('');
-      $('#sale_contact_email').val('');
-      $('#sale_contact_telephone').val('');
-      for (var x = 0; x < customer.contacts.length; x++) {
-        if (customer.primary_contact_id == customer.contacts[x].id) {
-          $('#contact_ref').val(customer.contacts[x].name);
-          $('#sale_contact_name').val(customer.contacts[x].name);
-          $('#sale_contact_email').val(customer.contacts[x].email);
-          $('#sale_contact_telephone').val(customer.contacts[x].telephone);
+      var contact_info = {
+        name: "",
+        email: customer.email,
+        telephone: customer.telephone
+      }
+
+      var contact = customer.contacts[0]
+      var primary_id = customer.primary_contact_id;
+      if (primary_id) {
+        for (var x = 0; x < customer.contacts.length; x++) {
+          if (primary_id == customer.contacts[x].id) {
+            contact = customer.contacts[x];
+          }
         }
       }
+      if (contact) {
+        if (contact.email && contact.email != "") {
+          contact_info.email = contact.email
+        }
+        if (contact.telephone && contact.telephone != "") {
+          contact_info.telephone = contact.telephone
+        }
+        contact_info.name = contact.name
+      }
+
+      $('#sale_contact_name').val(contact_info.name);
+      $('#sale_contact_email').val(contact_info.email);
+      $('#sale_contact_telephone').val(contact_info.telephone);
     }
 
     $('#sale_contact_name').typeahead({


### PR DESCRIPTION
I discovered an issue on the sales/new page.

If a customer lack a "contact", or haven't set the "primary contact" field, name/email is not filled in, which menas the invoice email can't be sent.

This PR adds more checks and fallbacks to sales/new